### PR TITLE
Version bump + generic-ec compat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /Cargo.lock
+.rstags

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 ff = { version = "0.13", features = ["derive"] }
 hex-literal = "0.3"
-primeorder = { git = "https://github.com/RustCrypto/elliptic-curves/", rev = "d4dbe19" }
+primeorder = "0.13"
 subtle = "2"
 zeroize = "1.5"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,3 +70,9 @@ impl From<Scalar> for ScalarPrimitive<StarkCurve> {
         ScalarPrimitive::from_uint_unchecked(s.to_uint())
     }
 }
+
+impl From<&Scalar> for ScalarPrimitive<StarkCurve> {
+    fn from(s: &Scalar) -> Self {
+        ScalarPrimitive::from_uint_unchecked(s.to_uint())
+    }
+}


### PR DESCRIPTION
- Use released `elliptic-curves` version instead of github revision
- Add a `From` impl same as other curves