### PR TITLE
Fix requiring std and alloc in some dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ keywords = ["elliptic-curves", "stark-curve"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ff = { version = "0.13", features = ["derive"] }
+ff = { version = "0.13", default-features = false, features = ["derive"] }
 hex-literal = "0.3"
 primeorder = "0.13"
-subtle = "2"
-zeroize = "1.5"
+subtle = { version = "2", default-features = false }
+zeroize = { version = "1.5", default-features = false }
 
 [dev-dependencies]
 rand = "0.8"


### PR DESCRIPTION
Closes #4 

Turns out it wasn't just subtle, a lot of crates require more than we need by default