### PR TITLE
Publish v0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stark-curve"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Stark curve implementation"


### PR DESCRIPTION
PR bumps the lib version. I'll cut a release when it's merged.