### PR TITLE
Update katex-header.html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.1.3
+* Update `katex-header.html` file injected into docs [#12]
+
+[#12]: https://github.com/LFDT-Lockness/stark-curve/pull/12
+
 ## v0.1.2
 * Update links in the crate, add info about our discord to readme [#9]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stark-curve"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Stark curve implementation"

--- a/katex-header.html
+++ b/katex-header.html
@@ -1,11 +1,20 @@
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.13.13/dist/katex.min.css" integrity="sha384-RZU/ijkSsFbcmivfdRBQDtwuwVqK7GMOw6IMvKyeWL2K5UAlyp6WonmB8m7Jd0Hn" crossorigin="anonymous" type="text/css">
-<script defer src=
-"https://cdn.jsdelivr.net/npm/katex@0.13.13/dist/katex.min.js" integrity="sha384-pK1WpvzWVBQiP0/GjnvRxV4mOb0oxFuyRxJlk6vVw146n3egcN5C925NCP7a7BY8" crossorigin="anonymous" type="text/javascript">
+<link rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/katex@0.13.13/dist/katex.min.css"
+  integrity="sha384-RZU/ijkSsFbcmivfdRBQDtwuwVqK7GMOw6IMvKyeWL2K5UAlyp6WonmB8m7Jd0Hn"
+  crossorigin="anonymous" type="text/css">
+<script defer
+  src="https://cdn.jsdelivr.net/npm/katex@0.13.13/dist/katex.min.js"
+  integrity="sha384-pK1WpvzWVBQiP0/GjnvRxV4mOb0oxFuyRxJlk6vVw146n3egcN5C925NCP7a7BY8"
+  crossorigin="anonymous" type="text/javascript">
 </script>
-<script defer src="https://cdn.jsdelivr.net/npm/katex@0.13.13/dist/contrib/auto-render.min.js" integrity="sha384-vZTG03m+2yp6N6BNi5iM4rW4oIwk5DfcNdFfxkk9ZWpDriOkXX8voJBFrAO7MpVl" crossorigin="anonymous" type="text/javascript">
+<script defer
+  src="https://cdn.jsdelivr.net/npm/katex@0.13.13/dist/contrib/auto-render.min.js"
+  integrity="sha384-vZTG03m+2yp6N6BNi5iM4rW4oIwk5DfcNdFfxkk9ZWpDriOkXX8voJBFrAO7MpVl"
+  crossorigin="anonymous" type="text/javascript">
 </script>
+
 <script type="text/javascript">
-document.addEventListener("DOMContentLoaded", function() {
+  document.addEventListener("DOMContentLoaded", function() {
     renderMathInElement(document.body, {
         delimiters: [
             {left: "$$", right: "$$", display: true},
@@ -22,8 +31,8 @@ document.addEventListener("DOMContentLoaded", function() {
             "\\V": "\\mathcal{V}",
             "\\H": "\\mathcal{H}",
             "\\?": "\\stackrel{?}{=}",
-            "\\ith": "i^{\\text{th}}",
         },
     });
-});
+  });
 </script>
+


### PR DESCRIPTION
PR updates katex-header.html file to be the same across all repos. Some of them were broken and caused double header menu displayed on docs.rs. I update all repos regardless of whether the katex header was broken, to sync all repos.